### PR TITLE
CatalogController breaks on Rails 5.1 - updated render text: to render plain:

### DIFF
--- a/lib/blacklight_oai_provider/catalog_controller_behavior.rb
+++ b/lib/blacklight_oai_provider/catalog_controller_behavior.rb
@@ -15,7 +15,7 @@ module BlacklightOaiProvider
     # first found min/max from result set.
     def oai
       options = params.delete_if { |k| %w(controller action format).include?(k) }
-      render text: oai_provider.process_request(options).gsub('<?xml version="1.0" encoding="UTF-8"?>', "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<?xml-stylesheet type=\"text/xsl\" href=\"#{ActionController::Base.helpers.asset_path('oai2.xsl')}\" ?>"), content_type: 'text/xml'
+      render plain: oai_provider.process_request(options).gsub('<?xml version="1.0" encoding="UTF-8"?>', "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<?xml-stylesheet type=\"text/xsl\" href=\"#{ActionController::Base.helpers.asset_path('oai2.xsl')}\" ?>"), content_type: 'text/xml'
     end
 
     # Uses Blacklight.config, needs to be modified when


### PR DESCRIPTION
This is a small fix to address a breaking change from Rails 5.0 to 5.1 .

Rails 5.1 has changed `render text:` to `render plain:`. This change breaks the CatalogController. 

[http://guides.rubyonrails.org/layouts_and_rendering.html#rendering-text](http://guides.rubyonrails.org/layouts_and_rendering.html#rendering-text)